### PR TITLE
refactor: remove useless context fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,18 +7,19 @@ Please beware that this is a PROTOTYPE. Do NOT use this for serious work. Thanks
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
+
 - [Introduction](#introduction)
-  - [Getting Started](#getting-started)
+    - [Getting Started](#getting-started)
   - [Adding Prisma Framework](#adding-prisma-framework)
 - [Conventions](#conventions)
-  - [Special File Names](#special-file-names)
-  - [`schema.ts`](#schemats)
-  - [`context.ts`](#contextts)
-  - [`app.ts`](#appts)
-  - [Prisma Support](#prisma-support)
-  - [Example Layouts](#example-layouts)
+    - [Special File Names](#special-file-names)
+    - [`schema.ts`](#schemats)
+    - [`context.ts`](#contextts)
+    - [`app.ts`](#appts)
+    - [Prisma Support](#prisma-support)
+    - [Example Layouts](#example-layouts)
 - [API](#api)
-  - [`createApp`](#createapp)
+    - [`createApp`](#createapp)
 - [CLI](#cli)
   - [`pumpkins build`](#pumpkins-build)
   - [`pumpkins dev`](#pumpkins-dev)
@@ -27,9 +28,9 @@ Please beware that this is a PROTOTYPE. Do NOT use this for serious work. Thanks
   - [`pumpkins help [COMMAND]`](#pumpkins-help-command)
   - [`pumpkins init`](#pumpkins-init)
 - [Development](#development)
-  - [Overview](#overview)
-  - [Testing](#testing)
-  - [Working With Example Apps via Linking](#working-with-example-apps-via-linking)
+    - [Overview](#overview)
+    - [Testing](#testing)
+    - [Working With Example Apps via Linking](#working-with-example-apps-via-linking)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -383,13 +384,12 @@ Create an app instance
 # CLI
 
 <!-- commands -->
-
-- [`pumpkins build`](#pumpkins-build)
-- [`pumpkins dev`](#pumpkins-dev)
-- [`pumpkins doctor`](#pumpkins-doctor)
-- [`pumpkins generate`](#pumpkins-generate)
-- [`pumpkins help [COMMAND]`](#pumpkins-help-command)
-- [`pumpkins init`](#pumpkins-init)
+* [`pumpkins build`](#pumpkins-build)
+* [`pumpkins dev`](#pumpkins-dev)
+* [`pumpkins doctor`](#pumpkins-doctor)
+* [`pumpkins generate`](#pumpkins-generate)
+* [`pumpkins help [COMMAND]`](#pumpkins-help-command)
+* [`pumpkins init`](#pumpkins-init)
 
 ## `pumpkins build`
 
@@ -480,7 +480,6 @@ EXAMPLE
 ```
 
 _See code: [dist/cli/commands/init.js](https://github.com/prisma-labs/pumpkins/blob/v0.0.0-sha.e4f6989/dist/cli/commands/init.js)_
-
 <!-- commandsstop -->
 
 # Development

--- a/src/utils/nexus-config.ts
+++ b/src/utils/nexus-config.ts
@@ -7,10 +7,8 @@ export type NexusConfig = Nexus.core.SchemaConfig
 
 export function createNexusConfig({
   generatedPhotonPackagePath: photonPath,
-  contextPath,
 }: {
   generatedPhotonPackagePath: string
-  contextPath: string
 }): NexusConfig {
   const projectDir = findProjectDir()
   const defaultSchemaPath = path.join(projectDir, 'schema.graphql')
@@ -24,8 +22,7 @@ export function createNexusConfig({
       typegen: defaultTypesPath,
     },
     typegenAutoConfig: {
-      contextType: 'Context.Context',
-      sources: [{ source: contextPath, alias: 'Context' }],
+      sources: [],
     },
     shouldGenerateArtifacts: shouldGenerateArtifacts(),
     shouldExitAfterGenerateArtifacts: shouldExitAfterGenerateArtifacts(),

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -83,10 +83,11 @@ export function sourceFilePathFromTranspiledPath({
   return path.join(rootDir, maybeAppFolders, tsFileName)
 }
 
-export function findFile(fileNames: string[]) {
+export function findFile(fileNames: string | string[]) {
+  const paths = Array.isArray(fileNames) ? fileNames : [fileNames]
   const foundFiles = fs.find({
     matching: [
-      ...fileNames,
+      ...paths,
       '!node_modules/**/*',
       '!.yalc/**/*',
       `!.${pumpkinsDotFolderName}/**/*`,

--- a/src/utils/scaffold.ts
+++ b/src/utils/scaffold.ts
@@ -1,5 +1,5 @@
 import * as fs from 'fs-jetpack'
-import { findFile, pumpkinsPath } from './path'
+import { findFile } from './path'
 import { log } from './log'
 
 export function findOrScaffold({


### PR DESCRIPTION
This is is being done to simplify upcoming PRs.

Since we have turned prisma into a plugin, there is actually nothing useful for us to offer in the context fallback.